### PR TITLE
Automatically parse URLs

### DIFF
--- a/app/controllers/teams/topics/application_controller.rb
+++ b/app/controllers/teams/topics/application_controller.rb
@@ -10,7 +10,7 @@ module Teams
       end
 
       def parse_markdown(markdown)
-        CommonMarker.render_html(markdown, :DEFAULT, %i[tasklist tagfilter])
+        CommonMarker.render_html(markdown, :DEFAULT, %i[tasklist tagfilter autolink])
       end
     end
   end


### PR DESCRIPTION
Also can't test this locally yet, but I believe this will work per https://github.com/gjtorikian/commonmarker#extensions.

Closes https://github.com/async-go/asyncgo/issues/90