### PR TITLE
Prompt for authorization account

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,7 +2,7 @@
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'],
-    {
-      prompt: 'select_account'
-    }
+           {
+             prompt: 'select_account'
+           }
 end


### PR DESCRIPTION
Adds explicit request to prompt, allowing for the user to have a chance to choose which account they want to use.

Closes https://github.com/async-go/asyncgo/issues/58