### PR TITLE
Make comments have more lines for editing

### DIFF
--- a/app/views/teams/topics/comments/edit.html.haml
+++ b/app/views/teams/topics/comments/edit.html.haml
@@ -10,6 +10,6 @@
     .mb-3
       .input-group
         .input-group-text Body
-        = form.text_area :body, required: true, class: 'form-control'
+        = form.text_area :body, rows: '4', required: true, class: 'form-control'
 
     = form.submit 'Update Comment', class: 'btn btn-primary'

--- a/app/views/teams/topics/show.html.haml
+++ b/app/views/teams/topics/show.html.haml
@@ -40,6 +40,6 @@
           local: true, class: 'row g-3') do |form|
           = form.hidden_field :user_id, value: current_user.id
           .col-lg-10
-            = form.text_area :body, required: true, class: 'form-control'
+            = form.text_area :body, rows: '4', required: true, class: 'form-control'
           .col-lg-2
             = form.submit 'Create Comment', class: 'btn btn-primary'


### PR DESCRIPTION
This makes comment have 4 lines instead of the default 2, making it slightly easier to edit longer comments.