### PR TITLE
Redirect to create team page if user doesn't have one

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
-  def index
-    redirect_to new_team_path if current_user.present? && current_user.team_id.blank?
-  end
+  def index; end
 end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,10 +1,19 @@
 %h2 Welcome to AsyncGo
-%br
+
+%p.lead
+  - if current_user&.team_id.present?
+    You're all set! Feel free to hop into the topics list! =>
+    = link_to 'Team Topics', team_topics_path(current_user.team)
+  - elsif current_user
+    Woohoo, you're signed in. The next step is to either get invited to a team or create one. =>
+    = link_to 'Create New Team', new_team_path
+  - else
+    Hi - the first step is to sign in.
+
 %p
   Documentation is available on our #{link_to('docs site', 'https://docs.asyncgo.com')}
   and general product information can be found on our
   #{link_to('home page', 'https://asyncgo.com')}.
-
 %p
   Cookie consent policy (and choices), privacy policy, and terms of use can be found on our
   #{link_to('main website', 'https://asyncgo.com/policies.html')}. These policies are for use of

--- a/app/views/teams/topics/show.html.haml
+++ b/app/views/teams/topics/show.html.haml
@@ -28,9 +28,7 @@
           = form.hidden_field :status, value: :active
           = form.submit 'Reopen Topic', class: 'btn btn-primary'
 
-%hr
-
-.row
+.row.border-top.mb-2
   %ul.list-group.list-group-flush
     - @topic.comments.each do |comment|
       %li.list-group-item
@@ -40,7 +38,7 @@
           .col-lg-3
             %span= comment.user.email
           .col-lg-2
-            - if @topic.active?
+            - if @topic.active? && policy([:teams, :topics, comment]).edit?
               %span= link_to 'Edit Comment',
                 edit_team_topic_comment_path(@topic.team, @topic, comment)
     - if @topic.active?

--- a/app/views/user_mailer/welcome_email.html.haml
+++ b/app/views/user_mailer/welcome_email.html.haml
@@ -2,7 +2,6 @@
 %p
   You have been invited to join #{@user.team.name} at AsyncGo.com,
   your email is: #{@user.email}.
-  %br
 %p
   To login to the site, just follow this link:
   %a{ href: 'https://app.asyncgo.com' } login


### PR DESCRIPTION
If a user has logged in and doesn't have a team, this takes them directly to the new team page.