### PR TITLE
Enhance support email info

### DIFF
--- a/app/views/support_mailer/support_email.html.haml
+++ b/app/views/support_mailer/support_email.html.haml
@@ -1,7 +1,5 @@
 %h2 Request Info
 %ul
-  %li From: #{@user.email}
-  %li Team Name: #{@user.team.name}
   %li Team ID: #{@user.team.id}
 
 %h2 Request Content

--- a/app/views/support_mailer/support_email.text.haml
+++ b/app/views/support_mailer/support_email.text.haml
@@ -1,8 +1,6 @@
 Request Info
 ================
 
-\- From: #{@user.email}
-\- Team Name: #{@user.team.name}
 \- Team ID: #{@user.team.id}
 
 Request Content

--- a/spec/mailers/support_mailer_spec.rb
+++ b/spec/mailers/support_mailer_spec.rb
@@ -18,16 +18,8 @@ RSpec.describe SupportMailer, type: :mailer do
       expect(mail.body.encoded).to include(body)
     end
 
-    it 'shows the team name' do
-      expect(mail.body.encoded).to include("Team Name: #{user.team.name}")
-    end
-
     it 'shows the team id' do
       expect(mail.body.encoded).to include("Team ID: #{user.team.id}")
-    end
-
-    it 'shows the sender email' do
-      expect(mail.body.encoded).to include("From: #{user.email}")
     end
   end
 end


### PR DESCRIPTION
Adds the senders team ID since team name can be ambiguous (multiple people could have a team named "test", for example).