### PR TITLE
Add logged in redirect for topic list

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,10 @@
 
 class HomeController < ApplicationController
   def index
-    redirect_to team_topics_path(current_user.team) if current_user&.team
+    if current_user&.team
+      redirect_to team_topics_path(current_user.team)
+    else
+      render :index
+    end
   end
 end

--- a/spec/system/topics_spec.rb
+++ b/spec/system/topics_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Topics', type: :system do
 
     visit '/'
     sign_in_user(user)
+    click_link 'Topics'
 
     topics.each do |topic|
       expect(page).to have_link(topic.title)


### PR DESCRIPTION
Sets up a redirect when logged in to go direct to the topic page.

Closes https://github.com/async-go/asyncgo/issues/63