### PR TITLE
Show login options without hamburger menu

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -5,7 +5,11 @@
     Woohoo, you're signed in. The next step is to either get invited to a team or create one. =>
     = link_to 'Create New Team', new_team_path
   - else
-    Hi - the first step is to sign in.
+    Hi - the first step is to sign in. You can do so using your
+    = link_to 'Google', '/auth/google_oauth2', method: 'post'
+    or
+    = link_to 'GitHub', '/auth/github', method: 'post'
+    account.
 %p.m-4
   = image_tag('happy_users.png', alt: 'Hello!', class: 'img-fluid')
 %p


### PR DESCRIPTION
On mobile it's annoying every time you have to log back in to open the hamburger menu, select the login secondary menu, and then click on the one you want. This makes quick links that are right there on the page and ready to go.