### PR TITLE
Fix mailer default URL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { host: 'asyngo.com' }
+  config.action_mailer.default_url_options = { host: 'app.asyncgo.com' }
 
   # SMTP settings for Google Mail
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
The URL used by the mailer in prod was wrong, this corrects it.