### PR TITLE
Stop snapping on resize

### DIFF
--- a/app/javascript/packs/text-area-autoresize.js
+++ b/app/javascript/packs/text-area-autoresize.js
@@ -1,10 +1,7 @@
+import autosize from 'autosize'
+
 document.addEventListener('turbolinks:load', function () {
   document.querySelectorAll('.text-area-autoresize').forEach(function (element) {
-    element.style.height = element.scrollHeight + 'px'
-    element.addEventListener('input', function (event) {
-      if (parseInt(event.target.style.height, 10) <= event.target.scrollHeight) {
-        event.target.style.height = event.target.scrollHeight + 'px'
-      }
-    })
+    autosize(element)
   })
 })

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/activestorage": "^6.1.1",
     "@rails/ujs": "^6.1.1",
     "@rails/webpacker": "5.2.1",
+    "autosize": "^4.0.2",
     "bootstrap": "^5.0.0-beta1",
     "turbolinks": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,6 +1439,11 @@ autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
+autosize@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/autosize/-/autosize-4.0.2.tgz#073cfd07c8bf45da4b9fd153437f5bafbba1e4c9"
+  integrity sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
This fixes the snapping weirdness that makes working with long descriptions a pain. Setting height to auto was triggering the snapping. Now, it only does that on removing lines, which feels more natural. Or if not, at least it's less frequent and annoying.

If we want to get rid of it completely, we can remove ever setting auto. In this case it only ever grows, and doesn't shrink back when you delete stuff. Which is not terrible, but at this point I'm not sure which is worse.