### PR TITLE
More fixes for autoresize

### DIFF
--- a/app/javascript/packs/text-area-autoresize.js
+++ b/app/javascript/packs/text-area-autoresize.js
@@ -1,19 +1,19 @@
 document.addEventListener('turbolinks:load', function () {
   document.querySelectorAll('.text-area-autoresize').forEach(function (element) {
-    if (element.scrollHeight < (window.innerHeight * .6)) {
+    if (element.scrollHeight < (window.innerHeight * 0.6)) {
       element.style.height = 'auto'
       element.style.height = element.scrollHeight + 'px'
     } else {
       element.style.height = 'auto'
-      element.style.height = (window.innerHeight * .6) + 'px'
+      element.style.height = (window.innerHeight * 0.6) + 'px'
     }
     element.addEventListener('input', function (event) {
-      if (event.target.scrollHeight < (window.innerHeight * .6)) {
+      if (event.target.scrollHeight < (window.innerHeight * 0.6)) {
         event.target.style.height = 'auto'
         event.target.style.height = event.target.scrollHeight + 'px'
       } else {
         event.target.style.height = 'auto'
-        event.target.style.height = (window.innerHeight * .6) + 'px'
+        event.target.style.height = (window.innerHeight * 0.6) + 'px'
       }
     })
   })


### PR DESCRIPTION
There were still some issues on Firefox and this resolves all the ones that I saw. Also works with Chrome on Linux at least.

1. It runs the adjustments on already in place content (when this wasn't being done consistently, you could get different sizes for initial content vs. once you started editing.
2. Height is now relative (60%) to the viewport to provide a nice balance between size of the textarea and the window
3. With this configuration, `auto` doesn't cause any more snapping so can be re-added. It's better when it's there because it ensures consistent adjustment to the correct size.