### PR TITLE
Re-add terms and copyright

### DIFF
--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -19,6 +19,6 @@
   .row
     .col-lg-12
       %h3 Usage Information
-      .d-block &copy;2021 AsyncGo
-      = link_to 'Terms of Use / Privacy Policy', 'https://asyncgo.com/policies.html',
+      %p &copy;2021 AsyncGo
+      %p= link_to 'Terms of Use / Privacy Policy', 'https://asyncgo.com/policies.html',
         target: :_blank, rel: :noopener


### PR DESCRIPTION
This moves the deleted terms and copyright to the user page. There isn't any other obvious better place to put them really.