### PR TITLE
Update new topic button to be outside of item list

### DIFF
--- a/app/views/teams/topics/_topics.html.haml
+++ b/app/views/teams/topics/_topics.html.haml
@@ -25,5 +25,5 @@
       %p= empty_state_text
 
   - if new_form
-    %span.ms-2= link_to 'New Topic', new_team_topic_path(current_user.team),
-      class: 'btn btn-primary mt-3'
+    = link_to new_team_topic_path(current_user.team) do
+      %span.m-3.btn.btn-primary New Topic


### PR DESCRIPTION
The topic button is ugly inside of one of the item rows in dark mode, this fixes it. It's inside the span because otherwise the button was 100% width, but I'm not sure I did it the right way.