### PR TITLE
Remove obvious page titles

### DIFF
--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -1,4 +1,4 @@
-%h1 New Team
+%h1.visually-hidden New Team
 
 = render partial: 'shared/form_errors', locals: { model: @team }
 

--- a/app/views/teams/topics/new.html.haml
+++ b/app/views/teams/topics/new.html.haml
@@ -1,5 +1,5 @@
 .row.my-5
-  %h1 New Topic
+  %h1.visually-hidden New Topic
 
   = link_to 'Back to All Topics', team_topics_path(@topic.team)
 


### PR DESCRIPTION
Some pages are obvious what they are when you are looking at them, so don't show the name of the page except to screen readers.