### PR TITLE
Back to topic doesn't make sense anymore for new comments

### DIFF
--- a/app/views/teams/topics/comments/new.html.haml
+++ b/app/views/teams/topics/comments/new.html.haml
@@ -3,5 +3,3 @@
 
   = turbo_frame_tag 'new_comment' do
     = render partial: 'comment_form', locals: { comment: @comment }
-    = link_to 'Back to Topic', team_topic_path(@comment.topic.team, @comment.topic),
-      class: 'btn btn-secondary my-3'


### PR DESCRIPTION
It was still there, but if you used it it just cleared the whole comment section. Since you no longer leave the topic page to add a comment, the button can be removed.