### PR TITLE
Adjust overdue styling

### DIFF
--- a/app/helpers/teams/topics_helper.rb
+++ b/app/helpers/teams/topics_helper.rb
@@ -9,10 +9,9 @@ module Teams
     end
 
     def topic_due_date_span(topic)
-      alert_style = topic_overdue?(topic) ? 'text-white bg-info' : nil
-      classes = "rounded p-1 #{alert_style}"
+      alert_style = topic_overdue?(topic) ? 'rounded p-1 bg-info text-light' : nil
 
-      tag.span(class: classes) do
+      tag.span(class: alert_style) do
         topic_due_date_text(topic)
       end
     end
@@ -50,6 +49,7 @@ module Teams
 
     def topic_overdue?(topic)
       return false unless topic.due_date?
+      return false unless topic.active?
 
       topic.due_date.end_of_day < Time.now.utc
     end

--- a/spec/helpers/teams/topics_helper_spec.rb
+++ b/spec/helpers/teams/topics_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Teams::TopicsHelper, type: :helper do
 
     context 'when topic does not have due date' do
       it { is_expected.to have_text('No due date') }
-      it { is_expected.to match(/class=".*bg-success.*"/) }
+      it { is_expected.not_to match(/class/) }
     end
 
     context 'when topic has due date and is active' do
@@ -54,7 +54,7 @@ RSpec.describe Teams::TopicsHelper, type: :helper do
         end
 
         it { is_expected.to have_text('Due less than a minute ago') }
-        it { is_expected.to match(/class=".*bg-warning.*"/) }
+        it { is_expected.to match(/class="rounded p-1 bg-info text-light"/) }
       end
 
       context 'when topic is not overdue' do
@@ -67,7 +67,7 @@ RSpec.describe Teams::TopicsHelper, type: :helper do
         end
 
         it { is_expected.to have_text('Due in 3 days') }
-        it { is_expected.to match(/class=".*bg-success.*"/) }
+        it { is_expected.not_to match(/class/) }
       end
     end
 
@@ -78,7 +78,7 @@ RSpec.describe Teams::TopicsHelper, type: :helper do
       end
 
       it { is_expected.to have_text('Due Jan 1') }
-      it { is_expected.to match(/class=".*bg-warning.*"/) }
+      it { is_expected.not_to match(/class/) }
     end
   end
 


### PR DESCRIPTION
This doesn't show a warning at all if the item isn't overdue, and only uses info since something being overdue isn't always a warning state.