### PR TITLE
Add team name, user id, user name or email to support request

### DIFF
--- a/app/views/support_mailer/support_email.html.haml
+++ b/app/views/support_mailer/support_email.html.haml
@@ -1,6 +1,7 @@
 %h2 Request Info
 %ul
-  %li Team ID: #{@user.team.id}
+  %li Team ID: #{@user.team.id} (#{@user.team.name})
+  %li User ID: #{@user.id} (#{@user.name || @user.email})
 
 %h2 Request Content
 %p= @body

--- a/app/views/support_mailer/support_email.text.haml
+++ b/app/views/support_mailer/support_email.text.haml
@@ -1,7 +1,8 @@
 Request Info
 ================
 
-\- Team ID: #{@user.team.id}
+\- Team ID: #{@user.team.id} (#{@user.team.name})
+\- User ID: #{@user.id} (#{@user.name || @user.email})
 
 Request Content
 ================


### PR DESCRIPTION
I'm not sure at all this is correct. I mean, it's not complicated, but I'm not sure I'm handling the scenario where a user doesn't have a name correctly and I can't think of any way to test this locally.

Also, not sure but maybe it's better to show both name and email if they are available?

Another improvement idea might be to set the reply-to address to the user's email.