### PR TITLE
Add early access billing section

### DIFF
--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -36,6 +36,19 @@
 
 .row
   .col-lg-12
+    %h3 Billing
+    %p
+      Billing is not yet implemented, but you are invited to early access. If you
+      choose to participate we just ask that you give us feedback on how we can
+      improve the product, and in exchange this team will be free
+      forever.
+    %p
+      To request full access please use the contact form below.
+
+%hr
+
+.row
+  .col-lg-12
     %h3 Support/Feedback Form
     %p.lead Use this form to contact support and/or provide product feedback.
     = form_with(url: team_support_path(@team), class: 'g-3') do |support_form|


### PR DESCRIPTION
Adds a section to the admin page that tells you that billing is not yet set up, but you can request early access by submitting the support form.

It doesn't actually block anyone from doing anything whether or not they have "early access permissions"