### PR TITLE
Add owners to teams

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -7,8 +7,12 @@ class TeamsController < Teams::ApplicationController
     @team = team
     authorize(@team)
 
-    @pagy, @team_members = pagy(
+    @pagy_members, @team_members = pagy(
       team.users.where.not(email: current_user.email).order(:created_at)
+    )
+
+    @pagy_owners, @team_owners = pagy(
+      team.owners.order(:created_at) || nil
     )
   end
 
@@ -22,6 +26,7 @@ class TeamsController < Teams::ApplicationController
     authorize(@team)
 
     if @team.save
+      @team.owners << current_user
       @team.users << current_user
       redirect_to edit_team_path(@team),
                   flash: { success: 'Team was successfully created.' }

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,5 +5,6 @@ class Team < ApplicationRecord
   validates :message, presence: { allow_blank: false, allow_empty: false, allow_nil: true }
 
   has_many :users, dependent: :nullify
+  has_many :owners, dependent: :nullify
   has_many :topics, dependent: :destroy
 end

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -57,11 +57,34 @@
           .col-lg-3
             = link_to user.email, team_user_path(@team, user),
               method: :delete, class: 'list-group-item list-group-item-action text-center'
-    - if @pagy.pages > 1
+    - if @pagy_membeers.pages > 1
       .row.mt-3
-        != pagy_bootstrap_nav(@pagy)
+        != pagy_bootstrap_nav(@pagy_members)
 
 %hr
+
+.row
+  .col-lg-12
+    %h3 Owners of Team
+    - if @team_owners.nil?
+      %p.lead
+        This team has no owner. Would you like to claim it?
+    - else
+      %p.lead
+        Click to remove. If you want to remove yourself, have a team member
+        do it for you or contact support below.
+      .row
+        .list-group.list-group-horizontal-lg
+          - @team_owners.each do |user|
+            .col-lg-3
+              = link_to user.email, team_user_path(@team, user),
+                method: :delete, class: 'list-group-item list-group-item-action text-center'
+      - if @pagy_owneers.pages > 1
+        .row.mt-3
+          != pagy_bootstrap_nav(@pagy_owners)
+
+%hr
+
 
 .row
   .col-lg-12


### PR DESCRIPTION
Adds a list of owners to a team. Defaults to the creator being the owner, with no way to change it yet. Since we have teams that do not have an owner set, it provides an option for anyone to claim ownership. This will only matter for our first few teams, or if somehow the owner is deleted.