### PR TITLE
Fix off screen team members

### DIFF
--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -52,7 +52,7 @@
       Click to remove. If you want to remove yourself, have a team member
       do it for you or contact support below.
     .row
-      .list-group
+      .list-group.list-group-horizontal.flex-wrap
         - @team_members.each do |user|
           .col-lg-3
             = link_to user.email, team_user_path(@team, user),


### PR DESCRIPTION
The user list extends off the screen when there are more than four users, so this just makes it vertical to avoid issues.