### PR TITLE
Dont show owner twice

### DIFF
--- a/app/views/teams/topics/_topic.html.haml
+++ b/app/views/teams/topics/_topic.html.haml
@@ -32,11 +32,10 @@
         class: 'gravatar-img mb-1',
         alt: "#{topic.user.printable_name} (Creator)"),
           "mailto:#{topic.user.email}"
-      - topic.subscribed_users.each do |participant|
-        - unless topic.user == participant
-          = link_to image_tag("#{participant.gravatar_url}?s=20&d=retro",
-            class: 'gravatar-img mb-1', alt: participant.name),
-              "mailto:#{participant.email}"
+      - topic.subscribed_users.where.not(id: topic.user.id).each do |participant|
+        = link_to image_tag("#{participant.gravatar_url}?s=20&d=retro",
+          class: 'gravatar-img mb-1', alt: participant.name),
+            "mailto:#{participant.email}"
     .col-lg-4
       %p.text-secondary
         = topic_due_date_span(topic)

--- a/app/views/teams/topics/_topics.html.haml
+++ b/app/views/teams/topics/_topics.html.haml
@@ -17,11 +17,10 @@
               class: 'gravatar-img mb-1',
               alt: "#{topic.user.printable_name} (Creator)"),
                 "mailto:#{topic.user.email}"
-            - topic.subscribed_users.each do |participant|
-              - unless topic.user == participant
-                = link_to image_tag("#{participant.gravatar_url}?s=20&d=retro",
-                  class: 'gravatar-img mb-1', alt: participant.printable_name),
-                    "mailto:#{participant.email}"
+            - topic.subscribed_users.where.not(id: topic.user.id).each do |participant|
+              = link_to image_tag("#{participant.gravatar_url}?s=20&d=retro",
+                class: 'gravatar-img mb-1', alt: participant.printable_name),
+                  "mailto:#{participant.email}"
           .col-lg-2.mb-1
             = topic_due_date_span(topic)
           .col-lg-2.mb-1


### PR DESCRIPTION
This is a small change, I don't think the owner needs to be set apart if there's also a convention of them being shown first. I don't think the owner also needs to be differentiated whether or not they are a current participant. The owner themselves can already tell if they are a watcher by virtue of the star.

Instead of this:

<img width="759" alt="image" src="https://user-images.githubusercontent.com/3529318/113470699-de71d600-9457-11eb-9784-8c68c216be09.png">

It just shows the picture once.