### PR TITLE
Change way days are shown

### DIFF
--- a/app/helpers/teams/topics_helper.rb
+++ b/app/helpers/teams/topics_helper.rb
@@ -43,14 +43,11 @@ module Teams
     end
 
     def active_topic_due_date_text(topic)
+      due_date_day_diff = (topic.due_date - Time.now.utc.to_date).to_i
       if topic_overdue?(topic)
-        "Due #{pluralize((topic.due_date..Time.now.utc).count - 1, 'day')} ago"
-      elsif ((Time.now.utc.to_date..topic.due_date).count - 1).zero?
-        'Due today'
-      elsif (Time.now.utc.to_date..topic.due_date).count - 1 == 1
-        'Due tomorrow'
+        "Due #{pluralize(due_date_day_diff.abs, 'day')} ago"
       else
-        "Due in #{pluralize((Time.now.utc.to_date..topic.due_date).count - 1, 'day')}"
+        "Due in #{pluralize(due_date_day_diff, 'day')}"
       end
     end
 

--- a/spec/helpers/teams/topics_helper_spec.rb
+++ b/spec/helpers/teams/topics_helper_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Teams::TopicsHelper, type: :helper do
           travel_back
         end
 
-        it { is_expected.to have_text('Due tomorrow') }
+        it { is_expected.to have_text('Due in 1 day') }
         it { is_expected.not_to match(/class/) }
       end
     end


### PR DESCRIPTION
The way days were showing was confusing, because you could have a situation where something is due tomorrow and you get a notification that it's due tomorrow, but the display showed "due in two days" because it was 24+23 hours. This changes it so the day it shows as being due is relative to the current day, and even if there are 47 hours until the end of the next day, it will still call that tomorrow.

I.e., it should be saying on which day it's due not in "about how many days worth of hours" is it due.

Rubocop doesn't like the elsifs but I'm not sure how to express it in a different way. I thought about making it so it says "due yesterday" instead of "due 1 day ago" also, but that would add even more ifs.