### PR TITLE
Fix digest emails

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -8,7 +8,7 @@ task send_digest_emails: :environment do
       next unless user.preference.digest_enabled?
 
       recently_resolved_topics = team.topics.where(
-        updated_at: (Time.zone.now - 24.hours)..Time.zone.now, status: :resolved
+        updated_at: (Time.zone.now - 24.hours)..Time.zone.now, status: :closed
       )
       notifications = user.notifications.where(read_at: nil)
       next if user.notifications.empty? && recently_resolved_topics.empty?


### PR DESCRIPTION
Digests have been broken since we renamed the resolved state, which was a while ago. Is there an easy way to add logging/monitoring to the rake tasks we run? Both have been a bit unreliable and hard to troubleshoot.