### PR TITLE
Preserve line breaks in support email

### DIFF
--- a/app/views/support_mailer/support_email.html.haml
+++ b/app/views/support_mailer/support_email.html.haml
@@ -13,4 +13,4 @@
       %li Name: #{@user.printable_name}
 
 %h2 Request Content
-%p= @body
+%pre= @body


### PR DESCRIPTION
It's not markdown, but marking it as preformatted will ensure it comes across as entered.