### PR TITLE
Open links in markdown in a new window

### DIFF
--- a/app/services/markdown_parser.rb
+++ b/app/services/markdown_parser.rb
@@ -13,7 +13,8 @@ class MarkdownParser < ApplicationService
 
   def call
     result = process_mentions(@text)
-    process_markdown(result)
+    html_output = process_markdown(result)
+    process_links(html_output)
   end
 
   private
@@ -29,11 +30,16 @@ class MarkdownParser < ApplicationService
   end
 
   def process_markdown(markdown)
-    doc = Nokogiri::HTML.fragment(CommonMarker.render_html(markdown, :DEFAULT, %i[tasklist tagfilter autolink]))
-    doc.css('a').each do |link|
-      link['target'] = '_blank'
-    end
-    doc.to_s
+    CommonMarker.render_html(markdown, :DEFAULT, %i[tasklist tagfilter autolink])
+  end
+
+  def process_links(html_output)
+    Nokogiri::HTML.fragment(html_output).tap do |doc|
+      doc.css('a').each do |link|
+        link['target'] = '_blank'
+        link['rel'] = 'noopener'
+      end
+    end.to_s
   end
 
   def notify_user!(target_user)

--- a/spec/services/markdown_parser_spec.rb
+++ b/spec/services/markdown_parser_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe MarkdownParser, type: :service do
     subject(:call) { described_class.new(user, text, target).call }
 
     it 'processes mentions' do
-      expect(call).to include("<a href=\"mailto:#{target_user.email}\" target=\"_blank\">#{target_user.name}</a>")
+      expect(call).to include(
+        "<a href=\"mailto:#{target_user.email}\" target=\"_blank\" rel=\"noopener\">#{target_user.name}</a>"
+      )
     end
 
     it 'processes markdowns' do


### PR DESCRIPTION
One weird thing, this only seems to work with new comments/updates. Should we render markdown at display time instead of save time to avoid changes in markdown rendering not working on old content?