### PR TITLE
Make edit comment and edit topic buttons look more different

### DIFF
--- a/app/views/teams/topics/comments/_comment.html.haml
+++ b/app/views/teams/topics/comments/_comment.html.haml
@@ -10,8 +10,8 @@
       = render partial: 'teams/topics/vote_list_group', locals: { votable: comment }
     .col-lg-2.mt-2
       - if policy(comment).edit?
-        = link_to 'Edit',
+        = link_to 'Edit Comment',
           edit_team_topic_comment_path(comment.topic.team, comment.topic, comment),
-          class: 'btn btn-secondary btn-sm'
+          class: 'btn btn-light btn-sm'
   .row.mt-3
     %div!= comment.body_html


### PR DESCRIPTION
To avoid the edit button for a comment from looking too much like the edit button for a topic. Not 100% sure on the styling, maybe a button border would make it look nicer since it's light.