### PR TITLE
Separate lists from content below them

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,6 +43,10 @@ $primary: #203864;
   border: 1px solid #333;
 }
 
+.user-content ol, ul, ol ol, ul ul {
+  margin-bottom: 1rem;
+}
+
 .topic-label {
   background: lightgray;
   color: #333;

--- a/app/views/teams/topics/_topic.html.haml
+++ b/app/views/teams/topics/_topic.html.haml
@@ -72,12 +72,12 @@
   .row.mt-3
     .col-lg-8.border
       %h6.mt-2.text-secondary.small#topic-description Description
-      .p-3!= topic.description_html
+      .p-3.user-content!= topic.description_html
 
     .col-lg-4.border
       %h6.mt-2.text-secondary.small#topic-outcome
         Outcome
         - if topic.active?
           (Work in Progress)
-      .p-3
+      .p-3.user-content
         != topic.outcome_html || 'Content has not been started yet'

--- a/app/views/teams/topics/comments/_comment.html.haml
+++ b/app/views/teams/topics/comments/_comment.html.haml
@@ -14,4 +14,4 @@
           edit_team_topic_comment_path(comment.topic.team, comment.topic, comment),
           class: 'btn btn-outline-secondary btn-sm'
   .row.mt-3
-    %div!= comment.body_html
+    .p-3.user-content!= comment.body_html


### PR DESCRIPTION
This forces padding below lists in user content. So for this markdown:

```
- A
- B

Next paragraph
```

Instead of the below, which is what it renders today, it matches the above.

```
- A
- B
Next paragraph
```