### PR TITLE
Sort closed topics by last modified

### DIFF
--- a/app/controllers/teams/topics_controller.rb
+++ b/app/controllers/teams/topics_controller.rb
@@ -8,14 +8,11 @@ module Teams
       authorize(team, policy_class: TopicPolicy)
 
       @team = team
-      team_topics = team.topics.order(pinned: :desc)
-                        .by_due_date.includes(:user, :subscribed_users, :labels)
-      @pagy_active_topics, @active_topics = pagy(
-        filtered_topics(team_topics.active), page_param: 'active_page'
-      )
-      @pagy_closed_topics, @closed_topics = pagy(
-        filtered_topics(team_topics.closed).reorder(updated_at: :desc), page_param: 'closed_page'
-      )
+      team_topics = team.topics.includes(:user, :subscribed_users, :labels)
+      active_topics = team_topics.active.order(pinned: :desc).by_due_date
+      closed_topics = team_topics.closed.order(updated_at: :desc)
+      @pagy_active_topics, @active_topics = pagy(filtered_topics(active_topics), page_param: 'active_page')
+      @pagy_closed_topics, @closed_topics = pagy(filtered_topics(closed_topics), page_param: 'closed_page')
     end
 
     def new

--- a/spec/system/pagination_spec.rb
+++ b/spec/system/pagination_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe 'Pagination', type: :system do
     user = FactoryBot.create(:user, :team)
     FactoryBot.create_list(
       :topic, 20, user: user, team: user.team, status: :closed,
-                  due_date: Date.new(2020, 1, 1)
+                  updated_at: Date.new(2021, 1, 1)
     )
     FactoryBot.create(
       :topic, user: user, team: user.team, status: :closed,
-              due_date: Date.new(2021, 1, 1), title: 'thisisthelasttopic'
+              updated_at: Date.new(2020, 1, 1), title: 'thisisthelasttopic'
     )
 
     visit '/'


### PR DESCRIPTION
Due date becomes largely irrelevant, so this instead sorts closed topics by ones that were worked on most recently by default.