### PR TITLE
Make sure notifications are correct on navigation

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,7 +28,7 @@
             = image_tag('logo.svg', alt: 'AsyncGo logo', class: 'img-fluid')
             %span AsyncGo
           - if current_user&.team
-            %span.badge.bg-secondary.fs-6.ms-auto.me-3#notifications
+            %span.badge.bg-secondary.fs-6.ms-auto.me-3#notifications{ 'data-turbo-temporary': true }
               = link_to user_notifications_path(current_user), class: 'text-decoration-none' do
                 = assistive_icon('fas', 'bell', 'Has notification', classname: 'text-warning')
                 %span.ms-1.text-white= unique_unread_notifications.count


### PR DESCRIPTION
This seems to work. It shows the wrong number for a moment, but then resets it to the correct value. Discovered in a roundabout way starting at https://turbo.hotwire.dev/handbook/building#persisting-elements-across-page-loads.