### PR TITLE
Remove extra click in initial flow

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,8 @@ class HomeController < ApplicationController
   def index
     if current_user&.team
       redirect_to team_topics_path(current_user.team)
+    elsif current_user
+      redirect_to new_team_path
     else
       render :index
     end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -5,39 +5,30 @@
 
 %h1 Welcome to AsyncGo
 
-- if current_user
-  %p.lead
-    You're signed in. The next step is to either get invited to a team or create one. =>
-    = link_to 'Create New Team', new_team_path
-- else
-  %p
-    Documentation is available on our #{link_to('docs site', 'https://asyncgo.com/docs')}
-    and general product information can be found on our
-    #{link_to('home page', 'https://asyncgo.com')}.
-  %p.mt-5.fw-bold
-    Sign in/create an account with:
-  .row
-    .col-lg-2.mt-3.mx-3
-      = button_to '/auth/google_oauth2',
-        'data-turbo': false, class: 'btn btn-google mb-3' do
-        = assistive_icon('fab', 'google', 'Google', classname: 'me-2 text-white')
-        Google
-    .col-lg-2.mt-3.mx-3
-      = button_to '/auth/github',
-        'data-turbo': false, class: 'btn btn-github mb-3' do
-        = assistive_icon('fab', 'github', 'GitHub', classname: 'me-2 text-white')
-        GitHub
-    .col-lg-2.mt-3.mx-3
-      = button_to '/auth/microsoft_graph',
-        'data-turbo': false, class: 'btn btn-microsoft mb-3' do
-        = assistive_icon('fab', 'microsoft', 'Microsoft', classname: 'me-2 text-white')
-        Microsoft
-    .col-lg-2.mt-3.mx-3.small
-      = button_to '/auth/slack',
-        'data-turbo': false, class: 'btn btn-slack mb-3' do
-        = assistive_icon('fab', 'slack', 'Slack', classname: 'me-2 text-white')
-        Slack
-    .col-lg-10
+%p
+  Sign in or create an account
+.row
+  .col-lg-2.mt-3.mx-3
+    = button_to '/auth/google_oauth2',
+      'data-turbo': false, class: 'btn btn-google mb-3' do
+      = assistive_icon('fab', 'google', 'Google', classname: 'me-2 text-white')
+      Google
+  .col-lg-2.mt-3.mx-3
+    = button_to '/auth/github',
+      'data-turbo': false, class: 'btn btn-github mb-3' do
+      = assistive_icon('fab', 'github', 'GitHub', classname: 'me-2 text-white')
+      GitHub
+  .col-lg-2.mt-3.mx-3
+    = button_to '/auth/microsoft_graph',
+      'data-turbo': false, class: 'btn btn-microsoft mb-3' do
+      = assistive_icon('fab', 'microsoft', 'Microsoft', classname: 'me-2 text-white')
+      Microsoft
+  .col-lg-2.mt-3.mx-3.small
+    = button_to '/auth/slack',
+      'data-turbo': false, class: 'btn btn-slack mb-3' do
+      = assistive_icon('fab', 'slack', 'Slack', classname: 'me-2 text-white')
+      Slack
+  .col-lg-10
 
 %p.mt-5
   = image_tag('happy_users.png', alt: 'Hello!', class: 'img-fluid')

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -2,6 +2,13 @@
 
 = render partial: 'shared/form_errors', locals: { model: @team }
 
+%p.lead
+  Creating a team is the first step to getting started with AsyncGo
+%p
+  If you were expecting to join a team that already exists, check that the email
+  associated with the account you logged in with matches your invitation, or
+  contact your team admin.
+
 = form_with(model: @team) do |form|
   .mb-3
     .input-group
@@ -10,3 +17,6 @@
       = form.text_field :name, class: 'form-control'
 
   = form.submit 'Create Team', class: 'btn btn-primary'
+
+%p.mt-5
+  = image_tag('happy_users.png', alt: 'Hello!', class: 'img-fluid')


### PR DESCRIPTION
This takes you straight to the create team page and adds the context there if you need to create a team, rather than having it be a special case of the login screen.