### PR TITLE
Preview outcomes

### DIFF
--- a/app/helpers/teams/topics_helper.rb
+++ b/app/helpers/teams/topics_helper.rb
@@ -30,7 +30,7 @@ module Teams
       Digest::MD5.hexdigest(value.to_s)
     end
 
-    def preview_html(content)
+    def preview_text(content)
       if content.length > 300
         "#{content[0..300]}..."
       else

--- a/app/views/teams/topics/_topics.html.haml
+++ b/app/views/teams/topics/_topics.html.haml
@@ -47,7 +47,7 @@
                 = topic_due_date_span(topic)
             - if type == :resolved && topic.outcome
               %p.my-0.small.fst-italic
-                = raw preview_html(topic.outcome)
+                = preview_text(topic.outcome)
 
   - else
     %li.list-group-item

--- a/app/views/teams/topics/index.html.haml
+++ b/app/views/teams/topics/index.html.haml
@@ -33,7 +33,7 @@
   %h2#active-topics Active Topics
   = render partial: 'topics', locals: { topic_collection: @active_topics, topic_hotkeys: true,
     empty_state_text: 'Active topics will appear here. Try creating a new topic to get started.',
-    type: :active}
+    type: :active }
 - if @pagy_active_topics.pages > 1
   .row.mt-3
     != pagy_bootstrap_nav(@pagy_active_topics)


### PR DESCRIPTION
Not 100% sure on this one, what do you think @matteeyah? I like how you get to see the beginning of the outcomes in the decision, which in a lot of cases tells you enough or maybe gets you interested in reading more. It also makes the resolved topics seem different from active ones.

It doesn't work with _html output since I can't reliably trim it without mangling tags. I think it's ok though.