### PR TITLE
Fix safari issue, make page simpler

### DIFF
--- a/app/views/teams/topics/_topic.html.haml
+++ b/app/views/teams/topics/_topic.html.haml
@@ -6,9 +6,6 @@
     .col-auto.mt-1
       %p.m-0.text-secondary#topic-duedate
         = topic_due_date_span(topic)
-    .col-auto.mt-1
-      - topic.labels.each do |label|
-        %span.topic-label= label
     .col-auto.mt-1#topic-participants
       = link_to image_tag("#{topic.user.gravatar_url}?s=20&d=retro",
         class: 'gravatar-img mb-1',
@@ -20,6 +17,9 @@
           title: participant.name,
           class: 'gravatar-img mb-1', alt: participant.name),
             "mailto:#{participant.email}"
+    .col-auto.mt-1
+      - topic.labels.each do |label|
+        %span.topic-label= label
   .row.mt-1
     %hr
   .row.justify-content-end.gap-3


### PR DESCRIPTION
Safari was behaving weird with the header on the topic page. This simplifies it and also makes it better, and it works now. I should use col-auto more often.