### PR TITLE
Open external content in new tab

### DIFF
--- a/app/packs/entrypoints/application.js
+++ b/app/packs/entrypoints/application.js
@@ -19,7 +19,7 @@ Rails.start()
 ActiveStorage.start()
 
 // Open all external links in a new window
-addEventListener('click', function (event) {
+window.addEventListener('click', function (event) {
   const target = event.target
   const el = target.closest('a')
   if (el && !el.isContentEditable && el.host !== window.location.host) {


### PR DESCRIPTION
Adapted from https://github.com/basecamp/trix/issues/55

Trix doesn't seem to support any way to set that content should open in a new tab, so this restores that feature. I thought maybe it made sense to just run this globally for all external links? Not sure.

Adapted from workarounds discussed in https://github.com/basecamp/trix/issues/55