### PR TITLE
Improve blockquote styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,6 +55,25 @@ $primary: #203864;
       margin-bottom: 1rem;
     }
   }
+
+  > {
+    blockquote {
+      background: #f9f9f9;
+      border-left: 10px solid #ccc;
+      margin: 1.5em 10px;
+      padding: 0.5em 10px;
+    }
+    blockquote:before {
+      color: #ccc;
+      font-size: 4em;
+      line-height: 0.1em;
+      margin-right: 0.25em;
+      vertical-align: -0.4em;
+    }
+    blockquote p {
+      display: inline;
+    }
+  }
 }
 
 .topic-label {


### PR DESCRIPTION
Blockquote styling from bootstrap is a little too subtle to tell it's even happening, this makes it more clear and nicer.

![image](https://user-images.githubusercontent.com/3529318/117102209-226a3a80-ad78-11eb-9d4d-cbe7f32ddd63.png)

instead of

![image](https://user-images.githubusercontent.com/3529318/117102235-357d0a80-ad78-11eb-8588-2bf105aa6970.png)

for the same markdown.