### PR TITLE
Fix nested blockquotes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,16 +50,17 @@ $primary: #203864;
     ol, ul {
       margin-bottom: 1rem;
     }
-
-    blockquote {
-      background: #f9f9f9;
-      padding: 0.25rem 1.25rem;
-      font-size: 1rem;
-      margin: 0 0 20px;
-      border-left: 5px solid #ccc;
-    }
   }
 }
+
+blockquote {
+  background: #f9f9f9;
+  padding: 0.25rem 1.25rem;
+  font-size: 1rem;
+  margin: 0 0 20px;
+  border-left: 5px solid #ccc;
+}
+
 
 .topic-label {
   background: lightgray;


### PR DESCRIPTION
Maybe there's another way to do this? But I found that having blockquote be where it was meant that styling was flat for all blockquotes, instead of like this:

![image](https://user-images.githubusercontent.com/3529318/117319824-f5a74780-ae8b-11eb-9138-a99f560605c6.png)

Maybe there is some other way to say "apply this styling to blockquote under user-content, but also recursively"