### PR TITLE
Hot patch revert of issue causing failed pipelines

### DIFF
--- a/config/initializers/webpacker_patch.rb
+++ b/config/initializers/webpacker_patch.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# config/initializers/webpacker_patch.rb
-# revert of https://github.com/rails/webpacker/commit/3760588534c54527d21c684c2cb5ca30cafc0901
+# Revert of https://github.com/rails/webpacker/commit/3760588534c54527d21c684c2cb5ca30cafc0901
 module WebpackerChdirPatch
   def watched_files_digest
     unless watched_paths.empty?


### PR DESCRIPTION
Not sure if this is a great idea or not, but it is meant to fix the issue with pipelines having to be re-run all the time: https://github.com/rails/webpacker/issues/2801#issuecomment-831814869.

Related https://github.com/async-go/asyncgo/issues/542