### PR TITLE
Fix extension styling

### DIFF
--- a/app/controllers/teams/topics_controller.rb
+++ b/app/controllers/teams/topics_controller.rb
@@ -114,12 +114,12 @@ module Teams
     end
 
     def new_params
-      return unless params[:context].present? && params[:selection].present?
+      return if params[:context].blank?
 
       {
         description: <<~DESCRIPTION
           Created from: #{params[:context]}
-          #{params[:selection]}
+          #{"#{params[:selection].gsub(/^/m, '> ')}\n" if params[:selection].present?}
         DESCRIPTION
       }
     end


### PR DESCRIPTION
Adds quoting for the extension, ensures it works with optional selection, and adjust styles a bit (ensures there's consistently one extra space after the brought-in info).