### PR TITLE
Fix markdown editor issues with disabling/resetting

### DIFF
--- a/app/views/teams/topics/comments/_comment_form.html.haml
+++ b/app/views/teams/topics/comments/_comment_form.html.haml
@@ -6,4 +6,4 @@
     = form.label :body
   .mb-3
     = render partial: 'shared/markdown_text_area', locals: { form: form, name: :body }
-  = form.submit submit_action, class: 'btn btn-primary', id: 'addcommentbutton'
+  = form.submit submit_action, class: 'btn btn-primary'


### PR DESCRIPTION
It was allowing multiple submits, this fixes it by ensuring the editor resets (so there's no content to resubmit). This also prevents having to manually erase your last comment contents.