### PR TITLE
Remove table button so people don't run into issue

### DIFF
--- a/app/packs/controllers/toastui_editor_controller.js
+++ b/app/packs/controllers/toastui_editor_controller.js
@@ -26,7 +26,7 @@ export default class extends Controller {
         // 'indent',
         // 'outdent',
         'divider',
-        'table',
+        // 'table',
         // 'image',
         'link',
         'divider',


### PR DESCRIPTION
There's an issue where if you add a table it converts the whole content to escaped markdown, which breaks formatting, and then every time you edit it it adds more escapes. This removes the add table button from the editor so at least we don't guide people to the problem.