### PR TITLE
Fix rendering issue with strikethrough

### DIFF
--- a/app/services/markdown_parser.rb
+++ b/app/services/markdown_parser.rb
@@ -30,7 +30,7 @@ class MarkdownParser < ApplicationService
   end
 
   def process_markdown(markdown)
-    CommonMarker.render_html(markdown, :DEFAULT, %i[tasklist tagfilter autolink])
+    CommonMarker.render_html(markdown, :DEFAULT, %i[strikethrough tasklist tagfilter autolink])
   end
 
   def process_links(html_output)


### PR DESCRIPTION
With the strikethrough extension disabled, the content can get messed up (it inserts random BRs). It doesn't fix the underlying issue with random BRs appearing, but it does prevent it every time someone uses strikethrough.