### PR TITLE
Fix deprecation warning in spec

### DIFF
--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -198,10 +198,9 @@ RSpec.describe OmniauthCallbacksController, type: :request do
     end
 
     before do
-      authed_user = Struct.new(:token)
       strategy_double = instance_double(
         OmniAuth::Slack::OAuth2::AccessToken,
-        authed_user: authed_user.new({ token: 'test' })
+        authed_user: Struct.new(:token).new({ token: 'test' })
       )
       allow_any_instance_of(OmniAuth::Strategies::Slack).to receive(:access_token).and_return(strategy_double) # rubocop:disable RSpec/AnyInstance
 


### PR DESCRIPTION
https://rubyreferences.github.io/rubychanges/3.1.html#warning-on-passing-keywords-to-a-non-keyword-initialized-struct

```
/home/jason/code/asyncgo/spec/requests/omniauth_callbacks_controller_spec.rb:203: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
```